### PR TITLE
Fix useless call to default value

### DIFF
--- a/Sources/GlobalConf/Injection/InjectedConf+AutoInjectable.swift
+++ b/Sources/GlobalConf/Injection/InjectedConf+AutoInjectable.swift
@@ -7,9 +7,9 @@ import ServiceContextModule
 public extension InjectedConf where InjectedType : AutoInjectable {
 	
 	init(customContext: ConfContext? = nil) {
-		let defaultValue = InjectedType.AutoInjectionKey.defaultValue
-		if let customContext {self.erasedAccessor = { customContext.actualContext[InjectedType.AutoInjectionKey.self] ?? defaultValue! }}
-		else                 {self.erasedAccessor = {         Conf.currentContext[InjectedType.AutoInjectionKey.self] ?? defaultValue! }}
+		let defaultValue = { @Sendable in InjectedType.AutoInjectionKey.defaultValue }
+		if let customContext {self.erasedAccessor = { customContext.actualContext[InjectedType.AutoInjectionKey.self] ?? defaultValue()! }}
+		else                 {self.erasedAccessor = {         Conf.currentContext[InjectedType.AutoInjectionKey.self] ?? defaultValue()! }}
 	}
 	
 }

--- a/Sources/GlobalConf/Injection/InjectedConf+AutoInjectableMainActor.swift
+++ b/Sources/GlobalConf/Injection/InjectedConf+AutoInjectableMainActor.swift
@@ -8,9 +8,9 @@ import ServiceContextModule
 public extension InjectedConf where InjectedType : AutoInjectableMainActor {
 	
 	init(customContext: ConfContext? = nil) {
-		let defaultValue = InjectedType.AutoInjectionKey.defaultValue
-		if let customContext {self.erasedAccessor = { customContext.actualContext[InjectedType.AutoInjectionKey.self] ?? defaultValue! }}
-		else                 {self.erasedAccessor = {         Conf.currentContext[InjectedType.AutoInjectionKey.self] ?? defaultValue! }}
+		let defaultValue = { @MainActor @Sendable in InjectedType.AutoInjectionKey.defaultValue }
+		if let customContext {self.erasedAccessor = { MainActor.assumeIsolated{ customContext.actualContext[InjectedType.AutoInjectionKey.self] ?? defaultValue()! } }}
+		else                 {self.erasedAccessor = { MainActor.assumeIsolated{         Conf.currentContext[InjectedType.AutoInjectionKey.self] ?? defaultValue()! } }}
 	}
 	
 }

--- a/Sources/GlobalConf/Injection/InjectedConf+ConfKey.swift
+++ b/Sources/GlobalConf/Injection/InjectedConf+ConfKey.swift
@@ -8,16 +8,16 @@ public extension InjectedConf {
 	
 	init<InjectedKey : ConfKey>(_ keyPath: KeyPath<ConfKeys, InjectedKey.Type>, customContext: ConfContext? = nil)
 	where InjectedKey.Value == InjectedType {
-		let defaultValue = InjectedKey.defaultValue
-		if let customContext {self.erasedAccessor = { customContext.actualContext[InjectedKey.self] ?? defaultValue! }}
-		else                 {self.erasedAccessor = {         Conf.currentContext[InjectedKey.self] ?? defaultValue! }}
+		let defaultValue = { @Sendable in InjectedKey.defaultValue }
+		if let customContext {self.erasedAccessor = { customContext.actualContext[InjectedKey.self] ?? defaultValue()! }}
+		else                 {self.erasedAccessor = {         Conf.currentContext[InjectedKey.self] ?? defaultValue()! }}
 	}
 	
 	init<InjectedKey : ConfKey>(_ keyPath: KeyPath<ConfKeys, InjectedKey.Type>, customContext: ConfContext? = nil)
 	where InjectedKey.Value == @Sendable () -> InjectedType {
-		let defaultValue = InjectedKey.defaultValue
-		if let customContext {self.erasedAccessor = { customContext.actualContext[InjectedKey.self]?() ?? defaultValue!() }}
-		else                 {self.erasedAccessor = {         Conf.currentContext[InjectedKey.self]?() ?? defaultValue!() }}
+		let defaultValue = { @Sendable in InjectedKey.defaultValue }
+		if let customContext {self.erasedAccessor = { customContext.actualContext[InjectedKey.self]?() ?? defaultValue()!() }}
+		else                 {self.erasedAccessor = {         Conf.currentContext[InjectedKey.self]?() ?? defaultValue()!() }}
 	}
 	
 }

--- a/Sources/GlobalConf/Injection/InjectedConf+ConfKeyMainActor.swift
+++ b/Sources/GlobalConf/Injection/InjectedConf+ConfKeyMainActor.swift
@@ -9,16 +9,16 @@ public extension InjectedConf {
 	
 	init<InjectedKey : ConfKeyMainActor>(_ keyPath: KeyPath<ConfKeys, InjectedKey.Type>, customContext: ConfContext? = nil)
 	where InjectedKey.Value == InjectedType {
-		let defaultValue = InjectedKey.defaultValue
-		if let customContext {self.erasedAccessor = { customContext.actualContext[InjectedKey.self] ?? defaultValue! }}
-		else                 {self.erasedAccessor = {         Conf.currentContext[InjectedKey.self] ?? defaultValue! }}
+		let defaultValue = { @MainActor @Sendable in InjectedKey.defaultValue }
+		if let customContext {self.erasedAccessor = { MainActor.assumeIsolated{ customContext.actualContext[InjectedKey.self] ?? defaultValue()! } }}
+		else                 {self.erasedAccessor = { MainActor.assumeIsolated{         Conf.currentContext[InjectedKey.self] ?? defaultValue()! } }}
 	}
 	
 	init<InjectedKey : ConfKeyMainActor>(_ keyPath: KeyPath<ConfKeys, InjectedKey.Type>, customContext: ConfContext? = nil)
 	where InjectedKey.Value == @Sendable () -> InjectedType {
-		let defaultValue = InjectedKey.defaultValue
-		if let customContext {self.erasedAccessor = { customContext.actualContext[InjectedKey.self]?() ?? defaultValue!() }}
-		else                 {self.erasedAccessor = {         Conf.currentContext[InjectedKey.self]?() ?? defaultValue!() }}
+		let defaultValue = { @MainActor @Sendable in InjectedKey.defaultValue }
+		if let customContext {self.erasedAccessor = { MainActor.assumeIsolated{ customContext.actualContext[InjectedKey.self]?() ?? defaultValue()!() } }}
+		else                 {self.erasedAccessor = { MainActor.assumeIsolated{         Conf.currentContext[InjectedKey.self]?() ?? defaultValue()!() } }}
 	}
 	
 }

--- a/Tests/GlobalConfTests/UsageTests.swift
+++ b/Tests/GlobalConfTests/UsageTests.swift
@@ -43,8 +43,6 @@ final class UsageTests : XCTestCase {
 		XCTAssertEqual(DefaultInitTrackedService.initCount, 0)
 	}
 	
-	private let testNoDefaultValueCalledWhenOverrideIsSetLock = NSLock()
-	
 	@InjectedConf(\.initTrackedService)
 	var initTrackedService: InitTrackedService
 	

--- a/Tests/GlobalConfTests/UsageTests.swift
+++ b/Tests/GlobalConfTests/UsageTests.swift
@@ -8,6 +8,14 @@ import GlobalConfModule
 
 final class UsageTests : XCTestCase {
 	
+	class override func setUp() {
+		super.setUp()
+		
+		/* For the testNoDefaultValueCalledWhenOverrideIsSet test.
+		 * **MUST** be done _before_ the test is initialized. */
+		Conf.setRootValue(NotTrackedInitTrackedService(), for: \.initTrackedService)
+	}
+	
 	func testUsingNoActorService() {
 		noActorService.printHello()
 		noActorServiceFromKeyPath.printHello()
@@ -30,13 +38,9 @@ final class UsageTests : XCTestCase {
 	
 	
 	func testNoDefaultValueCalledWhenOverrideIsSet() {
-		testNoDefaultValueCalledWhenOverrideIsSetLock.lock()
-		defer {testNoDefaultValueCalledWhenOverrideIsSetLock.unlock()}
-		
-		let initialCount = DefaultInitTrackedService.initCount
-		Conf.setRootValue(NotTrackedInitTrackedService(), for: \.initTrackedService)
 		_ = initTrackedService
-		XCTAssertEqual(DefaultInitTrackedService.initCount, initialCount)
+		_ = Conf[\.initTrackedService]
+		XCTAssertEqual(DefaultInitTrackedService.initCount, 0)
 	}
 	
 	private let testNoDefaultValueCalledWhenOverrideIsSetLock = NSLock()


### PR DESCRIPTION
The problem is sometimes this useless call will initialize a bunch of stuff and potentially crash due to missing dependencies, invalid values, or other.
So we do not call the default value if it is not used.